### PR TITLE
Build image for aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     ```
 - clone or download this repository to the RHEL host
 - [download](https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.4/x86_64/product-software) RHEL boot ISO to root folder of the repository
-- make sure there is yum repo availabe with [yggdrasil](https://github.com/jakub-dzon/yggdrasil) and [device-worker](https://github.com/jakub-dzon/k4e-device-worker/)
+- make sure there is yum repo available with [yggdrasil](https://github.com/jakub-dzon/yggdrasil) and [device-worker](https://github.com/jakub-dzon/k4e-device-worker/)
 - create repo.toml pointing to above repo
     ```
     id = "agent"

--- a/blueprint.template
+++ b/blueprint.template
@@ -11,3 +11,18 @@ version = "*"
 name = "k4e-agent"
 version = "*"
 
+[[packages]]
+name = "dmidecode"
+version = "*"
+[[packages]]
+name = "ipmitool"
+version = "*"
+[[packages]]
+name = "smartmontools"
+version = "*"
+[[packages]]
+name = "file"
+version = "*"
+[[packages]]
+name = "util-linux"
+version = "*"

--- a/ks.cfg.template
+++ b/ks.cfg.template
@@ -9,8 +9,13 @@ text
 network --bootproto=dhcp
 user --name=core --groups=wheel --password=edge
 services --enabled=ostree-remount
-ostreesetup --nogpg --url=${REPO_URL} --osname=rhel --remote=edge --ref=rhel/8/x86_64/edge
+ostreesetup --nogpg --url=${REPO_URL} --osname=${OS_NAME} --remote=${REMOTE_OS_NAME} --ref=${REF}
 %post
+cat <<EOF > /etc/containers/containers.conf
+[engine]
+infra_image = "k8s.gcr.io/pause:3.4.1"
+EOF
+
 cat <<EOF > /etc/yggdrasil/config.toml
 log-level = "error"
 cert-file = "/etc/pki/consumer/cert.pem"

--- a/r4e-aarch-image.sh
+++ b/r4e-aarch-image.sh
@@ -1,23 +1,22 @@
-# script for creating an ISO that pulls a certain ostree image/repo from web server
+# script for creating an image that points to a certain ostree commit from web server
 # the image includes the agent RPM that communicates with server that monitors edge devices
 # at the end the following products will be available for download:
-#   - ISO file
 #   - ostree image
-#   - kickstart file (ISO already points to it)
+#   - kickstart file
 # input:
-#  - ip or hostname with port if different than 80 used for connecting to the local web server
-#  - a name for the image. allows using different ISO and ostree image for different types of edge devices
+#  - IP or hostname with port if different than 80 used for connecting to the local web server
+#  - a name for the image. allows using different ostree image for different types of edge devices
 #  - URL for connecting to the server that monitors edge devices
-#  - path to boot ISO file
+#  - URL for additional packages repository
 # script assumes that files `blueprint.template` and `ks.cfg.template` are present in the working directory
 set -e
 Usage() {
     echo "Usage:"
-    echo `basename $0` "<image-server-address> <image-name> <agent-server-url> <path-to-boot-iso>"
+    echo `basename $0` "<image-server-address> <image-name> <agent-server-url> [packages-repo-url]"
 }
 
 # check usage
-if [ $# != 4 ] ; then
+if [ "$#" -lt  3 ] ; then
     echo -e "bad usage\n"
     Usage
     exit 1
@@ -27,26 +26,44 @@ fi
 IMAGE_HOST=$1
 export IMAGE_NAME=$2
 export AGENT_URL=$3
-BOOT_ISO=$4
-export OS_NAME="rhel"
-export REMOTE_OS_NAME="edge"
-export REF="rhel/8/x86_64/edge"
 
 # prepare local variables
-IMAGE_BASE_URL=http://$IMAGE_HOST/$IMAGE_NAME
 BLUEPRINT_TEMPLATE=blueprint.template
 BLUEPRINT_FILE=blueprint.toml
 KICKSTART_TEMPLATE=ks.cfg.template
 KICKSTART_FILE=ks.cfg
+IMAGE_BASE_URL=http://$IMAGE_HOST/$IMAGE_NAME
 KICKSTART_URL=$IMAGE_BASE_URL/$KICKSTART_FILE
-export REPO_URL=$IMAGE_BASE_URL/repo
 IMAGE_FOLDER=/var/www/html/$IMAGE_NAME
-ISO_FILE=$IMAGE_FOLDER/$IMAGE_NAME-boot.iso
+
+export REPO_URL=$IMAGE_BASE_URL/repo
+export OS_NAME="rhel-edge"
+export REMOTE_OS_NAME=${OS_NAME}
+export REF="rhel/8/aarch64/edge"
 
 # make sure image does not already exist
 if [ -e $IMAGE_FOLDER ] ; then
     echo "$IMAGE_FOLDER already exists"
     exit 1
+fi
+
+# create source resource if rpm repository URL is provided
+if [ -n "$4" ] ; then
+  echo "creating source agent"
+  REPO_DIR=$(mktemp -d)
+  cat << EOF > $REPO_DIR/repo.toml
+id = "agent"
+name = "agent"
+description = "k4e agent repository"
+type = "yum-baseurl"
+url = "$4"
+check_gpg = false
+check_ssl = false
+system = false
+EOF
+
+  composer-cli sources add $REPO_DIR/repo.toml
+  rm -rf $REPO_DIR
 fi
 
 # create blueprint
@@ -71,34 +88,15 @@ echo "saving image to web folder"
 composer-cli compose image $BUILD_ID
 sudo mkdir $IMAGE_FOLDER
 sudo tar -xvf $BUILD_ID-commit.tar -C $IMAGE_FOLDER
-rm -f $BUILD_ID-commit.tar
 
 # create kickstart file and copy to web server
 echo "creating kickstart file $KICKSTART_FILE"
 envsubst < $KICKSTART_TEMPLATE > $KICKSTART_FILE
 sudo cp $KICKSTART_FILE $IMAGE_FOLDER
 
-# edit ISO content
-echo "copy and edit ISO contents of $BOOT_ISO"
-ISO_MNT=`mktemp -d`
-ISO_DIR=`mktemp -d`
-sudo mount $BOOT_ISO $ISO_MNT
-sudo cp -Rf $ISO_MNT/* $ISO_DIR
-sudo umount $ISO_MNT
-rm -rf $ISO_MNT
-sudo chown -R $USER:$GROUPS $ISO_DIR
-chmod -R 777 $ISO_DIR
-sed -i "s#append initrd=initrd.img#append initrd=initrd.img inst.ks=$KICKSTART_URL#" $ISO_DIR/isolinux/isolinux.cfg
-
-# create new ISO file
-echo "create $ISO_FILE from $ISO_DIR"
-VOLUME_ID=`isoinfo -d -i $BOOT_ISO  | grep 'Volume id:' | cut -d ':' -f2 | tr -d ' '`
-cd $ISO_DIR
-sudo genisoimage -U -r -v -T -J -joliet-long -V $VOLUME_ID -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot -e images/efiboot.img -no-emul-boot -o $ISO_FILE .
-cd -
-sudo implantisomd5 $ISO_FILE
-
 # cleanup
-rm -rf $ISO_DIR
+rm temp.out
+rm -f $BUILD_ID-commit.tar
+rm -f $REPO_DIR
 
-echo "ISO build completed successfully"
+echo "Image build completed successfully"


### PR DESCRIPTION
Several packages needs to be specified for aarch64 image.
Also, since the boot-ISO for aarch doesn't contain the isolinux folder,
some of the steps for x86 cannot be applied to it.

Kickstart references were also update to specify the value as listed on
the compose.json.

Signed-off-by: Moti Asayag <masayag@redhat.com>