### PR TITLE
Update minimum RHEL version to 8.6+ in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RHEL for edge
 ## Build ISO for edge devices
-- prepare host with RHEL8.5+ - 2 CPUs, 4GB memory and 20GB of storage. It may be a VM, CNV VM or physical appliance. Web server running must be reachable by edge devices.
+- prepare host with RHEL8.6+ - 2 CPUs, 4GB memory and 20GB of storage. It may be a VM, CNV VM or physical appliance. Web server running must be reachable by edge devices.
 - The root folder should have more than 15GB available, you can extend it by:
   * resize the virtual machine disk before that step make sure the VM isn't running
    ```


### PR DESCRIPTION
After the previous PR was merged, it is no longer possible to build on RHEL 8.5 due to changes in the JSON structure returned by the composer-cli command.

This impacts the documentation as it specifies RHEL 8.5 as the minimum version compatible with the script.

@masayag @bardielle can you take a look?

Thanks,

/Jordi